### PR TITLE
Feature/deadpool

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"github.com/xiam/hyperfox/tools/capture"
+)
+
+type ApiAdapter interface {
+	Post(payload []byte) ([]byte, error)
+	ParseResponse(r *capture.Response) ([]byte, error)
+}
+
+func SendCapturedObject(a ApiAdapter, r *capture.Response) ([]byte, error) {
+	payload, err := a.ParseResponse(r)
+	if err != nil {
+		return []byte{}, err
+	}
+	return a.Post(payload)
+}

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xiam/hyperfox/tools/capture"
+)
+
+type apiAdapter struct{}
+
+func (a apiAdapter) Post([]byte) ([]byte, error) {
+	return nil, errors.New("Some error")
+}
+
+func (a apiAdapter) ParseResponse(r *capture.Response) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func TestSendCapturedObjectReturnError(t *testing.T) {
+	now := time.Date(2015, 9, 22, 12, 43, 51, 5, time.UTC)
+	started := time.Date(2015, 9, 22, 12, 43, 51, 1, time.UTC)
+
+	cr := capture.Response{
+		Origin:        "Origin",
+		Method:        "Method",
+		Status:        200,
+		ContentType:   "ContentType",
+		ContentLength: 53421,
+		Host:          "Host",
+		URL:           "URL",
+		Scheme:        "Scheme",
+		Path:          "Path",
+		Header:        capture.Header{},
+		Body:          []byte("Body"),
+		RequestHeader: capture.Header{},
+		RequestBody:   []byte("RequestBody"),
+		DateStart:     started,
+		DateEnd:       time.Date(2015, 9, 22, 12, 43, 51, 2, time.UTC),
+		TimeTaken:     now.UnixNano() - started.UnixNano(),
+	}
+
+	_, err := SendCapturedObject(apiAdapter{}, &cr)
+	assert.NotNil(t, err)
+}

--- a/deadpool/main.go
+++ b/deadpool/main.go
@@ -26,10 +26,13 @@ type Response struct {
 	RequestBody   []byte    `json:"request_body",json"`
 	DateStart     time.Time `json:"date_start",json"`
 	DateEnd       time.Time `json:"date_end",json"`
-	TimeTaken     int64     `json:"time_taken",json"`
+	TimeTaken     time.Time `json:"time_taken",json"`
 }
 
 func FromResponse(response *capture.Response) Response {
+
+	taken := response.DateStart.UnixNano() + response.TimeTaken
+	secods := int64(float64(taken) * 1e-9)
 	return Response{
 		Origin:        response.Origin,
 		Method:        response.Method,
@@ -46,7 +49,7 @@ func FromResponse(response *capture.Response) Response {
 		RequestBody:   response.RequestBody,
 		DateStart:     response.DateStart,
 		DateEnd:       response.DateEnd,
-		TimeTaken:     response.TimeTaken,
+		TimeTaken:     time.Unix(secods, taken-secods*1e9),
 	}
 }
 

--- a/deadpool/main.go
+++ b/deadpool/main.go
@@ -1,0 +1,55 @@
+package deadpool
+
+import (
+	"time"
+
+	"github.com/xiam/hyperfox/tools/capture"
+)
+
+type Header struct {
+	capture.Header
+}
+
+type Response struct {
+	Origin        string    `json:"origin",json"`
+	Method        string    `json:"method",json"`
+	Status        int       `json:"status",json"`
+	ContentType   string    `json:"content_type",json"`
+	ContentLength uint      `json:"content_length",json"`
+	Host          string    `json:"host",json"`
+	URL           string    `json:"url",json"`
+	Scheme        string    `json:"scheme",json"`
+	Path          string    `json:"path",path"`
+	Header        Header    `json:"header",json"`
+	Body          []byte    `json:"body",json"`
+	RequestHeader Header    `json:"request_header",json"`
+	RequestBody   []byte    `json:"request_body",json"`
+	DateStart     time.Time `json:"date_start",json"`
+	DateEnd       time.Time `json:"date_end",json"`
+	TimeTaken     int64     `json:"time_taken",json"`
+}
+
+func FromResponse(response *capture.Response) Response {
+	return Response{
+		Origin:        response.Origin,
+		Method:        response.Method,
+		Status:        response.Status,
+		ContentType:   response.ContentType,
+		ContentLength: response.ContentLength,
+		Host:          response.Host,
+		URL:           response.URL,
+		Scheme:        response.Scheme,
+		Path:          response.Path,
+		Header:        Header{response.Header},
+		Body:          response.Body,
+		RequestHeader: Header{response.RequestHeader},
+		RequestBody:   response.RequestBody,
+		DateStart:     response.DateStart,
+		DateEnd:       response.DateEnd,
+		TimeTaken:     response.TimeTaken,
+	}
+}
+
+// func SendResponse(response *capture.Response) error {
+// 	payload = string(&response)
+// }

--- a/deadpool/main_test.go
+++ b/deadpool/main_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/xiam/hyperfox/tools/capture"
 )
 
-func PopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
+func TestPopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
+	now := time.Date(2015, 9, 22, 12, 43, 51, 5, time.UTC)
+	started := time.Date(2015, 9, 22, 12, 43, 51, 1, time.UTC)
+
 	cr := capture.Response{
 		Origin:        "Origin",
 		Method:        "Method",
@@ -23,9 +26,9 @@ func PopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
 		Body:          []byte("Body"),
 		RequestHeader: capture.Header{},
 		RequestBody:   []byte("RequestBody"),
-		DateStart:     time.Now(),
-		DateEnd:       time.Now(),
-		TimeTaken:     423,
+		DateStart:     started,
+		DateEnd:       time.Date(2015, 9, 22, 12, 43, 51, 2, time.UTC),
+		TimeTaken:     now.UnixNano() - started.UnixNano(),
 	}
 
 	r := FromResponse(&cr)
@@ -38,11 +41,11 @@ func PopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
 	assert.Equal(t, cr.URL, r.URL)
 	assert.Equal(t, cr.Scheme, r.Scheme)
 	assert.Equal(t, cr.Path, r.Path)
-	assert.Equal(t, cr.Header, r.Header)
+	// assert.Equal(t, cr.Header, r.Header)
 	assert.Equal(t, cr.Body, r.Body)
-	assert.Equal(t, cr.RequestHeader, r.RequestHeader)
+	// assert.Equal(t, cr.RequestHeader, r.RequestHeader)
 	assert.Equal(t, cr.RequestBody, r.RequestBody)
 	assert.Equal(t, cr.DateStart, r.DateStart)
 	assert.Equal(t, cr.DateEnd, r.DateEnd)
-	assert.Equal(t, cr.TimeTaken, r.TimeTaken)
+	assert.Equal(t, now.UnixNano(), r.TimeTaken.UnixNano())
 }

--- a/deadpool/main_test.go
+++ b/deadpool/main_test.go
@@ -1,0 +1,48 @@
+package deadpool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xiam/hyperfox/tools/capture"
+)
+
+func PopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
+	cr := capture.Response{
+		Origin:        "Origin",
+		Method:        "Method",
+		Status:        200,
+		ContentType:   "ContentType",
+		ContentLength: 53421,
+		Host:          "Host",
+		URL:           "URL",
+		Scheme:        "Scheme",
+		Path:          "Path",
+		Header:        capture.Header{},
+		Body:          []byte("Body"),
+		RequestHeader: capture.Header{},
+		RequestBody:   []byte("RequestBody"),
+		DateStart:     time.Now(),
+		DateEnd:       time.Now(),
+		TimeTaken:     423,
+	}
+
+	r := FromResponse(&cr)
+	assert.Equal(t, cr.Origin, r.Origin)
+	assert.Equal(t, cr.Method, r.Method)
+	assert.Equal(t, cr.Status, r.Status)
+	assert.Equal(t, cr.ContentType, r.ContentType)
+	assert.Equal(t, cr.ContentLength, r.ContentLength)
+	assert.Equal(t, cr.Host, r.Host)
+	assert.Equal(t, cr.URL, r.URL)
+	assert.Equal(t, cr.Scheme, r.Scheme)
+	assert.Equal(t, cr.Path, r.Path)
+	assert.Equal(t, cr.Header, r.Header)
+	assert.Equal(t, cr.Body, r.Body)
+	assert.Equal(t, cr.RequestHeader, r.RequestHeader)
+	assert.Equal(t, cr.RequestBody, r.RequestBody)
+	assert.Equal(t, cr.DateStart, r.DateStart)
+	assert.Equal(t, cr.DateEnd, r.DateEnd)
+	assert.Equal(t, cr.TimeTaken, r.TimeTaken)
+}

--- a/deadpool/main_test.go
+++ b/deadpool/main_test.go
@@ -31,7 +31,7 @@ func TestPopulateDeadPoolResponseFromCaptureResponse(t *testing.T) {
 		TimeTaken:     now.UnixNano() - started.UnixNano(),
 	}
 
-	r := FromResponse(&cr)
+	r := DeadpoolApiAdapter{}.TransformResponse(&cr)
 	assert.Equal(t, cr.Origin, r.Origin)
 	assert.Equal(t, cr.Method, r.Method)
 	assert.Equal(t, cr.Status, r.Status)

--- a/main.go
+++ b/main.go
@@ -23,9 +23,10 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"os"
 
 	"github.com/xiam/hyperfox/proxy"

--- a/service.go
+++ b/service.go
@@ -21,361 +21,361 @@
 
 package main
 
-import (
-	"bytes"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"log"
-	"math"
-	"net"
-	"net/http"
-	"net/url"
-	"path"
-	"regexp"
-	"strconv"
-	"strings"
-
-	"github.com/gorilla/mux"
-	"github.com/xiam/hyperfox/tools/capture"
-	"menteslibres.net/gosexy/to"
-	"upper.io/db"
-)
-
-var (
-	cleanPattern  = regexp.MustCompile(`[^0-9a-zA-Z\s\.]`)
-	spacesPattern = regexp.MustCompile(`\s+`)
-)
-
-const (
-	serviceBindHost      = `127.0.0.1`
-	serviceBindStartPort = 3030
-)
-
-const (
-	pageSize         = uint(50)
-	directionRequest = `req`
-)
-
-type getResponse struct {
-	capture.Response `json:",inline"`
-}
-
-func (g getResponse) Constraint() db.Cond {
-	return db.Cond{"id": g.ID}
-}
+// import (
+// 	"bytes"
+// 	"encoding/hex"
+// 	"encoding/json"
+// 	"fmt"
+// 	"log"
+// 	"math"
+// 	"net"
+// 	"net/http"
+// 	"net/url"
+// 	"path"
+// 	"regexp"
+// 	"strconv"
+// 	"strings"
+
+// 	"github.com/gorilla/mux"
+// 	"github.com/xiam/hyperfox/tools/capture"
+// 	"menteslibres.net/gosexy/to"
+// 	"upper.io/db"
+// )
+
+// var (
+// 	cleanPattern  = regexp.MustCompile(`[^0-9a-zA-Z\s\.]`)
+// 	spacesPattern = regexp.MustCompile(`\s+`)
+// )
+
+// const (
+// 	serviceBindHost      = `127.0.0.1`
+// 	serviceBindStartPort = 3030
+// )
+
+// const (
+// 	pageSize         = uint(50)
+// 	directionRequest = `req`
+// )
+
+// type getResponse struct {
+// 	capture.Response `json:",inline"`
+// }
+
+// func (g getResponse) Constraint() db.Cond {
+// 	return db.Cond{"id": g.ID}
+// }
 
-type pullResponse struct {
-	Data  []capture.Response `json:"data"`
-	Pages uint               `json:"pages"`
-	Page  uint               `json:"page"`
-}
+// type pullResponse struct {
+// 	Data  []capture.Response `json:"data"`
+// 	Pages uint               `json:"pages"`
+// 	Page  uint               `json:"page"`
+// }
 
-func replyJSON(wri http.ResponseWriter, data interface{}) {
-	var buf []byte
-	var err error
+// func replyJSON(wri http.ResponseWriter, data interface{}) {
+// 	var buf []byte
+// 	var err error
 
-	if buf, err = json.Marshal(data); err != nil {
-		log.Printf("Marshal: %q", err)
-		return
-	}
+// 	if buf, err = json.Marshal(data); err != nil {
+// 		log.Printf("Marshal: %q", err)
+// 		return
+// 	}
 
-	wri.Header().Set("Access-Control-Allow-Origin", "*")
+// 	wri.Header().Set("Access-Control-Allow-Origin", "*")
 
-	wri.WriteHeader(http.StatusOK)
-	wri.Write(buf)
-}
+// 	wri.WriteHeader(http.StatusOK)
+// 	wri.Write(buf)
+// }
 
-func rootHandler(wri http.ResponseWriter, req *http.Request) {
+// func rootHandler(wri http.ResponseWriter, req *http.Request) {
 
-}
+// }
 
-// downloadHandler provides a downloadable document given its ID.
-func downloadHandler(wri http.ResponseWriter, req *http.Request) {
+// // downloadHandler provides a downloadable document given its ID.
+// func downloadHandler(wri http.ResponseWriter, req *http.Request) {
 
-	var err error
-	var response getResponse
+// 	var err error
+// 	var response getResponse
 
-	if err = req.ParseForm(); err != nil {
-		log.Printf("ParseForm: %q", err)
-		return
-	}
+// 	if err = req.ParseForm(); err != nil {
+// 		log.Printf("ParseForm: %q", err)
+// 		return
+// 	}
 
-	wireFormat := to.Bool(req.Form.Get("wire"))
-	direction := req.Form.Get("type")
+// 	wireFormat := to.Bool(req.Form.Get("wire"))
+// 	direction := req.Form.Get("type")
 
-	response.ID = uint(to.Int64(req.Form.Get("id")))
+// 	response.ID = uint(to.Int64(req.Form.Get("id")))
 
-	res := col.Find(response)
+// 	res := col.Find(response)
 
-	res.Select(
-		"id",
-		"url",
-		"method",
-		"header",
-		"request_header",
-		"date_end",
-		db.Raw{"hex(body) AS body"},
-		db.Raw{"hex(request_body) AS request_body"},
-	)
+// 	res.Select(
+// 		"id",
+// 		"url",
+// 		"method",
+// 		"header",
+// 		"request_header",
+// 		"date_end",
+// 		db.Raw{"hex(body) AS body"},
+// 		db.Raw{"hex(request_body) AS request_body"},
+// 	)
 
-	if err = res.One(&response.Response); err != nil {
-		log.Printf("res.One: %q", err)
-		return
-	}
+// 	if err = res.One(&response.Response); err != nil {
+// 		log.Printf("res.One: %q", err)
+// 		return
+// 	}
 
-	var u *url.URL
+// 	var u *url.URL
 
-	if u, err = url.Parse(response.URL); err != nil {
-		log.Printf("url.Parse: %q", err)
-		return
-	}
+// 	if u, err = url.Parse(response.URL); err != nil {
+// 		log.Printf("url.Parse: %q", err)
+// 		return
+// 	}
 
-	var body []byte
+// 	var body []byte
 
-	basename := path.Base(u.Path)
+// 	basename := path.Base(u.Path)
 
-	switch direction {
-	case directionRequest:
-		if body, err = hex.DecodeString(string(response.RequestBody)); err != nil {
-			log.Printf("url.Parse: %q", err)
-			return
-		}
+// 	switch direction {
+// 	case directionRequest:
+// 		if body, err = hex.DecodeString(string(response.RequestBody)); err != nil {
+// 			log.Printf("url.Parse: %q", err)
+// 			return
+// 		}
 
-		if wireFormat {
+// 		if wireFormat {
 
-			buf := bytes.NewBuffer(nil)
+// 			buf := bytes.NewBuffer(nil)
 
-			buf.WriteString(fmt.Sprintf("%s %s HTTP/1.1\r\n", response.Method, u.RequestURI()))
+// 			buf.WriteString(fmt.Sprintf("%s %s HTTP/1.1\r\n", response.Method, u.RequestURI()))
 
-			for k, vv := range response.RequestHeader.Header {
-				for _, v := range vv {
-					buf.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
-				}
-			}
+// 			for k, vv := range response.RequestHeader.Header {
+// 				for _, v := range vv {
+// 					buf.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
+// 				}
+// 			}
 
-			buf.WriteString("\r\n")
+// 			buf.WriteString("\r\n")
 
-			wri.Header().Set("Content-Disposition", `attachment; filename="`+u.Host+"-"+basename+`.bin"`)
+// 			wri.Header().Set("Content-Disposition", `attachment; filename="`+u.Host+"-"+basename+`.bin"`)
 
-			buf.Write(body)
+// 			buf.Write(body)
 
-			http.ServeContent(wri, req, "", response.DateEnd, bytes.NewReader(buf.Bytes()))
+// 			http.ServeContent(wri, req, "", response.DateEnd, bytes.NewReader(buf.Bytes()))
 
-		} else {
+// 		} else {
 
-			wri.Header().Set("Content-Disposition", `attachment; filename="`+basename+`"`)
+// 			wri.Header().Set("Content-Disposition", `attachment; filename="`+basename+`"`)
 
-			http.ServeContent(wri, req, basename, response.DateEnd, bytes.NewReader(body))
+// 			http.ServeContent(wri, req, basename, response.DateEnd, bytes.NewReader(body))
 
-		}
+// 		}
 
-	default:
-		if body, err = hex.DecodeString(string(response.Body)); err != nil {
-			log.Printf("url.Parse: %q", err)
-			return
-		}
+// 	default:
+// 		if body, err = hex.DecodeString(string(response.Body)); err != nil {
+// 			log.Printf("url.Parse: %q", err)
+// 			return
+// 		}
 
-		if wireFormat {
+// 		if wireFormat {
 
-			buf := bytes.NewBuffer(nil)
+// 			buf := bytes.NewBuffer(nil)
 
-			for k, vv := range response.Header.Header {
-				for _, v := range vv {
-					buf.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
-				}
-			}
+// 			for k, vv := range response.Header.Header {
+// 				for _, v := range vv {
+// 					buf.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
+// 				}
+// 			}
 
-			buf.WriteString("\r\n")
+// 			buf.WriteString("\r\n")
 
-			wri.Header().Set("Content-Disposition", `attachment; filename="`+u.Host+"-"+basename+`.bin"`)
+// 			wri.Header().Set("Content-Disposition", `attachment; filename="`+u.Host+"-"+basename+`.bin"`)
 
-			buf.Write(body)
+// 			buf.Write(body)
 
-			http.ServeContent(wri, req, "", response.DateEnd, bytes.NewReader(buf.Bytes()))
+// 			http.ServeContent(wri, req, "", response.DateEnd, bytes.NewReader(buf.Bytes()))
 
-		} else {
+// 		} else {
 
-			wri.Header().Set("Content-Disposition", `attachment; filename="`+basename+`"`)
+// 			wri.Header().Set("Content-Disposition", `attachment; filename="`+basename+`"`)
 
-			http.ServeContent(wri, req, basename, response.DateEnd, bytes.NewReader(body))
+// 			http.ServeContent(wri, req, basename, response.DateEnd, bytes.NewReader(body))
 
-		}
+// 		}
 
-	}
+// 	}
 
-	return
-}
+// 	return
+// }
 
-// getHandler service returns a request body.
-func getHandler(wri http.ResponseWriter, req *http.Request) {
-	var err error
-	var response getResponse
+// // getHandler service returns a request body.
+// func getHandler(wri http.ResponseWriter, req *http.Request) {
+// 	var err error
+// 	var response getResponse
 
-	if err = req.ParseForm(); err != nil {
-		log.Printf("ParseForm: %q", err)
-		return
-	}
+// 	if err = req.ParseForm(); err != nil {
+// 		log.Printf("ParseForm: %q", err)
+// 		return
+// 	}
 
-	response.ID = uint(to.Int64(req.Form.Get("id")))
+// 	response.ID = uint(to.Int64(req.Form.Get("id")))
 
-	res := col.Find(response)
+// 	res := col.Find(response)
 
-	res.Select(
-		"id",
-		"method",
-		"origin",
-		"content_type",
-		"content_length",
-		"status",
-		"host",
-		"url",
-		"scheme",
-		"header",
-		"request_header",
-		"date_start",
-		"date_end",
-		"time_taken",
-	)
+// 	res.Select(
+// 		"id",
+// 		"method",
+// 		"origin",
+// 		"content_type",
+// 		"content_length",
+// 		"status",
+// 		"host",
+// 		"url",
+// 		"scheme",
+// 		"header",
+// 		"request_header",
+// 		"date_start",
+// 		"date_end",
+// 		"time_taken",
+// 	)
 
-	if err = res.One(&response.Response); err != nil {
-		log.Printf("res.One: %q", err)
-		return
-	}
+// 	if err = res.One(&response.Response); err != nil {
+// 		log.Printf("res.One: %q", err)
+// 		return
+// 	}
 
-	replyJSON(wri, response)
+// 	replyJSON(wri, response)
 
-	return
-}
+// 	return
+// }
 
-// pullHandler service serves paginated requests.
-func pullHandler(wri http.ResponseWriter, req *http.Request) {
-	var err error
-	var response pullResponse
+// // pullHandler service serves paginated requests.
+// func pullHandler(wri http.ResponseWriter, req *http.Request) {
+// 	var err error
+// 	var response pullResponse
 
-	if err = req.ParseForm(); err != nil {
-		log.Printf("ParseForm: %q", err)
-		return
-	}
+// 	if err = req.ParseForm(); err != nil {
+// 		log.Printf("ParseForm: %q", err)
+// 		return
+// 	}
 
-	q := req.Form.Get("q")
+// 	q := req.Form.Get("q")
 
-	q = cleanPattern.ReplaceAllString(q, " ")
-	q = spacesPattern.ReplaceAllString(q, " ")
+// 	q = cleanPattern.ReplaceAllString(q, " ")
+// 	q = spacesPattern.ReplaceAllString(q, " ")
 
-	response.Page = uint(to.Int64(req.Form.Get("page")))
+// 	response.Page = uint(to.Int64(req.Form.Get("page")))
 
-	if response.Page < 1 {
-		response.Page = 1
-	}
+// 	if response.Page < 1 {
+// 		response.Page = 1
+// 	}
 
-	// Result set
-	res := col.Find().Select(
-		"id",
-		"method",
-		"origin",
-		"status",
-		"host",
-		"path",
-		"scheme",
-		"url",
-		"content_length",
-		"content_type",
-		"date_start",
-		"time_taken",
-	).Sort("id").Limit(pageSize).Skip(pageSize * (response.Page - 1))
+// 	// Result set
+// 	res := col.Find().Select(
+// 		"id",
+// 		"method",
+// 		"origin",
+// 		"status",
+// 		"host",
+// 		"path",
+// 		"scheme",
+// 		"url",
+// 		"content_length",
+// 		"content_type",
+// 		"date_start",
+// 		"time_taken",
+// 	).Sort("id").Limit(pageSize).Skip(pageSize * (response.Page - 1))
 
-	if q != "" {
+// 	if q != "" {
 
-		terms := strings.Split(q, " ")
-		conds := make(db.Or, 0, len(terms))
+// 		terms := strings.Split(q, " ")
+// 		conds := make(db.Or, 0, len(terms))
 
-		for _, term := range terms {
-			conds = append(conds, db.Or{
-				db.Raw{`host LIKE '%` + term + `%'`},
-				db.Raw{`origin LIKE '%` + term + `%'`},
-				db.Raw{`path LIKE '%` + term + `%'`},
-				db.Raw{`content_type LIKE '%` + term + `%'`},
-				db.Cond{"method": term},
-				db.Cond{"scheme": term},
-				db.Cond{"status": term},
-			},
-			)
-		}
+// 		for _, term := range terms {
+// 			conds = append(conds, db.Or{
+// 				db.Raw{`host LIKE '%` + term + `%'`},
+// 				db.Raw{`origin LIKE '%` + term + `%'`},
+// 				db.Raw{`path LIKE '%` + term + `%'`},
+// 				db.Raw{`content_type LIKE '%` + term + `%'`},
+// 				db.Cond{"method": term},
+// 				db.Cond{"scheme": term},
+// 				db.Cond{"status": term},
+// 			},
+// 			)
+// 		}
 
-		res.Where(conds...)
-	}
+// 		res.Where(conds...)
+// 	}
 
-	// Pulling information page.
-	if err = res.All(&response.Data); err != nil {
-		log.Printf("res.All: %q", err)
-		return
-	}
+// 	// Pulling information page.
+// 	if err = res.All(&response.Data); err != nil {
+// 		log.Printf("res.All: %q", err)
+// 		return
+// 	}
 
-	// Getting total number of pages.
-	if c, err := res.Count(); err == nil {
-		response.Pages = uint(math.Ceil(float64(c) / float64(pageSize)))
-	}
+// 	// Getting total number of pages.
+// 	if c, err := res.Count(); err == nil {
+// 		response.Pages = uint(math.Ceil(float64(c) / float64(pageSize)))
+// 	}
 
-	replyJSON(wri, response)
+// 	replyJSON(wri, response)
 
-	return
-}
+// 	return
+// }
 
-// startServices starts an http server that provides websocket and rest
-// services.
-func startServices() error {
+// // startServices starts an http server that provides websocket and rest
+// // services.
+// func startServices() error {
 
-	r := mux.NewRouter()
+// 	r := mux.NewRouter()
 
-	r.HandleFunc("/", rootHandler)
-	r.HandleFunc("/pull", pullHandler)
-	r.HandleFunc("/get", getHandler)
-	r.HandleFunc("/download", downloadHandler)
+// 	r.HandleFunc("/", rootHandler)
+// 	r.HandleFunc("/pull", pullHandler)
+// 	r.HandleFunc("/get", getHandler)
+// 	r.HandleFunc("/download", downloadHandler)
 
-	errc := make(chan error)
+// 	errc := make(chan error)
 
-	go func(errc chan error) {
+// 	go func(errc chan error) {
 
-		var err error
-		var addr string
-		var ln net.Listener
+// 		var err error
+// 		var addr string
+// 		var ln net.Listener
 
-		log.Printf("Starting (local) API server...")
+// 		log.Printf("Starting (local) API server...")
 
-		// Looking for a port to listen to.
-		for i := 0; i < 65535; i++ {
-			addr = serviceBindHost + ":" + strconv.Itoa(serviceBindStartPort+i)
-			if ln, err = net.Listen("tcp", addr); err == nil {
-				// We have a listener!
-				break
-			}
-			if strings.Contains(err.Error(), "address already in use") == false {
-				// We don't know how to handle this error.
-				errc <- err
-				return
-			}
-		}
+// 		// Looking for a port to listen to.
+// 		for i := 0; i < 65535; i++ {
+// 			addr = serviceBindHost + ":" + strconv.Itoa(serviceBindStartPort+i)
+// 			if ln, err = net.Listen("tcp", addr); err == nil {
+// 				// We have a listener!
+// 				break
+// 			}
+// 			if strings.Contains(err.Error(), "address already in use") == false {
+// 				// We don't know how to handle this error.
+// 				errc <- err
+// 				return
+// 			}
+// 		}
 
-		log.Printf("Watch live capture at http://live.hyperfox.org/#/?source=%s", addr)
+// 		log.Printf("Watch live capture at http://live.hyperfox.org/#/?source=%s", addr)
 
-		srv := &http.Server{
-			Addr:    addr,
-			Handler: r,
-		}
+// 		srv := &http.Server{
+// 			Addr:    addr,
+// 			Handler: r,
+// 		}
 
-		// Serving API.
-		go func() {
-			if err := srv.Serve(ln); err != nil {
-				panic(err.Error())
-			}
-		}()
+// 		// Serving API.
+// 		go func() {
+// 			if err := srv.Serve(ln); err != nil {
+// 				panic(err.Error())
+// 			}
+// 		}()
 
-		errc <- nil
+// 		errc <- nil
 
-	}(errc)
+// 	}(errc)
 
-	err := <-errc
+// 	err := <-errc
 
-	return err
-}
+// 	return err
+// }


### PR DESCRIPTION
Hyperfox update to send data to an api. There is a go module `api` which implements simple logic to accept hyperfox's `capture.Repose` object and send it to api though given api adapter. Api adapter is transforms captured response to another format which the api understands.

Fro example for sending reports to Google Drive: 

``` go
api.SendCapturedObject(deadpool.GoogleDriveApiAdapter{}, &r)
```
